### PR TITLE
[HACK] Better/Simpler Gitpod support

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,10 +1,5 @@
 FROM gitpod/workspace-full
 USER gitpod
 
-RUN curl -sL https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer| bash
-
-RUN ["/bin/bash", "-c", ". /home/gitpod/.gvm/scripts/gvm && gvm install go1.17 -B"]
-RUN ["/bin/bash", "-c", ". /home/gitpod/.gvm/scripts/gvm && gvm use go1.17"]
-
-    
-
+RUN brew tap suborbital/subo && \
+    brew install subo

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,25 +1,6 @@
 image:
   file: .gitpod.dockerfile
 
-tasks:
-  - name: initialize
-    init: |
-
-      # ------------------------------------
-      # GoLang
-      # ------------------------------------
-      source /home/gitpod/.gvm/scripts/gvm
-      gvm use go1.17
-
-      # ------------------------------------
-      # Subo
-      # ------------------------------------
-      git clone https://github.com/suborbital/subo
-      cd subo
-      make subo
-      cd ..
-      rm -rf subo
-
 ports:
   - port: 8080
     visibility: public


### PR DESCRIPTION
## Hacktoberfest contribution

It's possible to use brew with Linux, and it's installed by default in the GitPod image. After the first build, the loading of the workspace will be quicker because we don't need anymore to build the **subo** CLI